### PR TITLE
Change event may not be triggered, leaving input_text in old state

### DIFF
--- a/lovelace-text-input-row.js
+++ b/lovelace-text-input-row.js
@@ -18,17 +18,20 @@ class TextInputRow extends Polymer.Element {
   }
 
 
-  _handleTouchStart(ev){
-    // Blur and dispatch change event.
-    this.$.textinput.blur();
+  _handleEventTrigger(ev){
+    // Dispatch change event.
     var event = new Event('change');
+    this.$.textinput.blur();
     this.$.textinput.dispatchEvent(event);
+
+
   }
 
   connectedCallback() {
     super.connectedCallback();
-    this.boundTouchStartHandler = this._handleTouchStart.bind(this);
+    this.boundTouchStartHandler = this._handleEventTrigger.bind(this);
     window.addEventListener('touchstart', this.boundTouchStartHandler, { passive: true, useCapture: true});
+    window.addEventListener('mousedown', this.boundTouchStartHandler, { passive: true, useCapture: true});
   }
 
   disconnectedCallback() {

--- a/lovelace-text-input-row.js
+++ b/lovelace-text-input-row.js
@@ -17,6 +17,25 @@ class TextInputRow extends Polymer.Element {
     `;
   }
 
+
+  _handleTouchStart(ev){
+    // Blur and dispatch change event.
+    this.$.textinput.blur();
+    var event = new Event('change');
+    this.$.textinput.dispatchEvent(event);
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this.boundTouchStartHandler = this._handleTouchStart.bind(this);
+    window.addEventListener('touchstart', this.boundTouchStartHandler, { passive: true, useCapture: true});
+  }
+
+  disconnectedCallback() {
+    window.removeEventListener('touchstart', this.boundTouchStartHandler);
+    super.disconnectedCallback();
+  }
+
   ready() {
     super.ready();
     this.$.textinput.addEventListener('click', ev => ev.stopPropagation());
@@ -32,7 +51,9 @@ class TextInputRow extends Polymer.Element {
       entity_id: this._config.entity,
       value: newValue,
     };
-    this._hass.callService('input_text', 'set_value', param);
+    if (this.value != newValue) {
+      this._hass.callService('input_text', 'set_value', param);
+    }
   }
 
   computeObjectId(entityId) {


### PR DESCRIPTION
This PR has 2 changes:
  1. fire a change event when ever the window is clicked or touched on
  2.  only update the input_text back via service if value is changed.

I made this change as field was not updating when I pushed a button to call a service, so the old value was used.  